### PR TITLE
Bump evenement version to match react 0.4.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "phergie/phergie-irc-client-react": "dev-master",
         "phergie/phergie-irc-connection": "dev-master",
         "phergie/phergie-irc-event": "dev-master",
-        "evenement/evenement": "1.0.*",
+        "evenement/evenement": "2.0.*",
         "monolog/monolog": "1.6.*"
     },
     "repositories": [


### PR DESCRIPTION
Since phergie-irc-client-react now uses react 0.4, the evenement version needs to be bumped here to allow composer to resolve deps properly.

Cheers!
