### PR TITLE
Updated dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
         "phergie/phergie-irc-client-react": "2.*",
         "phergie/phergie-irc-connection": "1.*",
         "phergie/phergie-irc-event": "1.*",
-        "evenement/evenement": "2.0.*",
-        "monolog/monolog": "1.6.*"
+        "evenement/evenement": "~2.0",
+        "monolog/monolog": "~1.6"
     },
     "repositories": [
         {


### PR DESCRIPTION
```
 Problem 1
    - symfony/monolog-bundle v2.6.0 requires monolog/monolog ~1.8 -> satisfiable by monolog/monolog[1.10.0, 1.11.0, 1.8.0, 1.9.0, 1.9.1].
    - symfony/monolog-bundle v2.6.1 requires monolog/monolog ~1.8 -> satisfiable by monolog/monolog[1.10.0, 1.11.0, 1.8.0, 1.9.0, 1.9.1].
    - Can only install one of: monolog/monolog[1.6.0, 1.10.0].
    - Can only install one of: monolog/monolog[1.6.0, 1.11.0].
    - Can only install one of: monolog/monolog[1.8.0, 1.6.0].
    - Can only install one of: monolog/monolog[1.9.0, 1.6.0].
    - Can only install one of: monolog/monolog[1.9.1, 1.6.0].
    - phergie/phergie-irc-bot-react 1.0.0 requires monolog/monolog 1.6.* -> satisfiable by monolog/monolog[1.6.0].
    - Installation request for phergie/phergie-irc-bot-react ~1.0 -> satisfiable by phergie/phergie-irc-bot-react[1.0.0].
    - Installation request for symfony/monolog-bundle ~2.6 -> satisfiable by symfony/monolog-bundle[v2.6.0, v2.6.1].
```
