### PR TITLE
Partition the priority queue as an internal property of EventQueue

### DIFF
--- a/src/EventQueueInterface.php
+++ b/src/EventQueueInterface.php
@@ -18,7 +18,7 @@ use Phergie\Irc\GeneratorInterface;
  * @category Phergie
  * @package Phergie\Irc\Bot\React
  */
-interface EventQueueInterface extends GeneratorInterface, \Iterator, \Countable
+interface EventQueueInterface extends GeneratorInterface, \IteratorAggregate, \Countable
 {
     /**
      * Removes and returns an event from the front of the queue.

--- a/src/EventQueueInternal.php
+++ b/src/EventQueueInternal.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Phergie (http://phergie.org)
+ * @copyright Copyright (c) 2008-2015 Phergie Development Team (http://phergie.org)
+ * @license http://phergie.org/license Simplified BSD License
+ * @package Phergie\Irc\Bot\React
+ */
+
+namespace Phergie\Irc\Bot\React;
+
+/**
+ * Implementation of SplPriorityQueue specifically for internal use within
+ * the EventQueue class.
+ *
+ * @category Phergie
+ * @package Phergie\Irc\Bot\React
+ */
+class EventQueueInternal extends \SplPriorityQueue
+{
+    /**
+     * Overrides native default comparison logic to assign higher priority to
+     * events inserted earlier.
+     *
+     * @param \Phergie\Irc\Bot\React\EventQueuePriority $priority1
+     * @param \Phergie\Irc\Bot\React\EventQueuePriority $priority2
+     * @return int
+     */
+    public function compare($priority1, $priority2)
+    {
+        if (!$priority1 instanceof EventQueuePriority || !$priority2 instanceof EventQueuePriority) {
+            return parent::compare($priority1, $priority2);
+        }
+
+        $priority = $priority1->value - $priority2->value;
+        if (!$priority) {
+            $priority = $priority2->timestamp - $priority1->timestamp;
+        }
+        return $priority;
+    }
+}

--- a/tests/EventQueueTest.php
+++ b/tests/EventQueueTest.php
@@ -222,4 +222,25 @@ class EventQueueTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull($this->queue->extract());
     }
+
+    /**
+     * Tests that iterating over the event queue does not truncate its contents.
+     */
+    public function testNonDestructiveIteration()
+    {
+        $this->assertNull($this->queue->extract());
+
+        $this->queue->ircQuit();
+        $contents = [];
+        foreach ($this->queue as $value) {
+            $contents[] = $value;
+        }
+
+        $event = $this->queue->extract();
+        $this->assertInstanceOf('\Phergie\Irc\Event\EventInterface', $event);
+        $this->assertEquals('QUIT', $event->getCommand());
+        $this->assertEmpty($event->getParams());
+
+        $this->assertEquals([$event], $contents);
+    }
 }


### PR DESCRIPTION
EventQueue now implements SplPriorityQueue as an internal property, rather than by extending the class directly.

Fixes: #9