### PR TITLE
Add PluginContainerInterface for plugins that have nested plugins

### DIFF
--- a/src/Bot.php
+++ b/src/Bot.php
@@ -342,6 +342,11 @@ class Bot
         foreach ($processors as $processor) {
             foreach ($plugins as $plugin) {
                 $processor->process($plugin, $this);
+                if ($plugin instanceof PluginContainerInterface) {
+                    foreach ($plugin->getPlugins() as $childPlugin) {
+                        $processor->process($childPlugin, $this);
+                    }
+                }
             }
         }
     }

--- a/src/Bot.php
+++ b/src/Bot.php
@@ -336,17 +336,24 @@ class Bot
      *
      * @param \Phergie\Irc\Bot\React\PluginInterface[]
      * @param \Phergie\Irc\Bot\React\PluginProcessor\PluginProcessorInterface[]
+     * @param \SplObjectStorage $processedPlugins
      */
-    protected function processPlugins(array $plugins, array $processors)
+    protected function processPlugins(array $plugins, array $processors, \SplObjectStorage $processedPlugins = null)
     {
-        foreach ($processors as $processor) {
-            foreach ($plugins as $plugin) {
+        // Initialise store of already-processed plugins, to prevent container-based endless recursion
+        if ($processedPlugins === null) {
+            $processedPlugins = new \SplObjectStorage;
+        }
+        foreach ($plugins as $plugin) {
+            if ($processedPlugins->contains($plugin)) {
+                continue;
+            }
+            $processedPlugins->attach($plugin);
+            foreach ($processors as $processor) {
                 $processor->process($plugin, $this);
-                if ($plugin instanceof PluginContainerInterface) {
-                    foreach ($plugin->getPlugins() as $childPlugin) {
-                        $processor->process($childPlugin, $this);
-                    }
-                }
+            }
+            if ($plugin instanceof PluginContainerInterface) {
+                $this->processPlugins($plugin->getPlugins(), $processors, $processedPlugins);
             }
         }
     }

--- a/src/PluginContainerInterface.php
+++ b/src/PluginContainerInterface.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Phergie (http://phergie.org)
+ *
+ * @link http://github.com/phergie/phergie-irc-bot-react for the canonical source repository
+ * @copyright Copyright (c) 2008-2015 Phergie Development Team (http://phergie.org)
+ * @license http://phergie.org/license Simplified BSD License
+ * @package Phergie\Irc\Bot\React
+ */
+
+namespace Phergie\Irc\Bot\React;
+
+/**
+ * Interface for plugins that contain nested plugins which
+ * the bot would not ordinarily be aware of.
+ *
+ * @category Phergie
+ * @package Phergie\Irc\Bot\React
+ */
+interface PluginContainerInterface
+{
+    /**
+     * Returns an array of plugins within the container.
+     *
+     * @return \Phergie\Irc\Bot\React\Plugin[]
+     */
+    public function getPlugins();
+}


### PR DESCRIPTION
Allows the bot to call plugin processors on nested plugins that are not a part of `$config['plugins']`.