### PR TITLE
Adds a new EventQueueFactoryAwareInterface for plugins

### DIFF
--- a/src/AbstractPlugin.php
+++ b/src/AbstractPlugin.php
@@ -25,7 +25,8 @@ abstract class AbstractPlugin implements
     PluginInterface,
     LoggerAwareInterface,
     EventEmitterAwareInterface,
-    ClientAwareInterface
+    ClientAwareInterface,
+    EventQueueFactoryAwareInterface
 {
     /**
      * Client for any adjustments the plugin may want to make
@@ -48,6 +49,14 @@ abstract class AbstractPlugin implements
      * @var \Psr\Log\LoggerInterface
      */
     protected $logger;
+
+    /**
+     * Event queue factory, which gets the event queue instance for a given
+     * connection instance.
+     *
+     * @var \Phergie\Irc\Bot\React\EventQueueFactoryInterface
+     */
+    protected $queueFactory;
 
     /**
      * Sets the client for the plugin to use.
@@ -107,6 +116,26 @@ abstract class AbstractPlugin implements
     public function getLogger()
     {
         return $this->logger;
+    }
+
+    /**
+     * Sets the event queue factory instance.
+     *
+     * @param \Phergie\Irc\Bot\React\EventQueueFactoryInterface $factory
+     */
+    public function setEventQueueFactory(EventQueueFactoryInterface $queueFactory)
+    {
+        $this->queueFactory = $queueFactory;
+    }
+
+    /**
+     * Returns the event queue factory instance.
+     *
+     * @return \Phergie\Irc\Bot\React\EventQueueFactoryInterface
+     */
+    public function getEventQueueFactory()
+    {
+        return $this->queueFactory;
     }
 
     /**

--- a/src/Bot.php
+++ b/src/Bot.php
@@ -13,6 +13,7 @@ namespace Phergie\Irc\Bot\React;
 use Monolog\Logger;
 use Phergie\Irc\Bot\React\PluginProcessor\ClientInjector;
 use Phergie\Irc\Bot\React\PluginProcessor\EventEmitterInjector;
+use Phergie\Irc\Bot\React\PluginProcessor\EventQueueFactoryInjector;
 use Phergie\Irc\Bot\React\PluginProcessor\LoggerInjector;
 use Phergie\Irc\Bot\React\PluginProcessor\LoopInjector;
 use Phergie\Irc\Bot\React\PluginProcessor\PluginProcessorInterface;
@@ -404,6 +405,7 @@ class Bot
         return array(
             new ClientInjector,
             new EventEmitterInjector,
+            new EventQueueFactoryInjector,
             new LoggerInjector,
             new LoopInjector,
         );

--- a/src/EventQueueFactoryAwareInterface.php
+++ b/src/EventQueueFactoryAwareInterface.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Phergie (http://phergie.org)
+ *
+ * @link http://github.com/phergie/phergie-irc-bot-react for the canonical source repository
+ * @copyright Copyright (c) 2008-2015 Phergie Development Team (http://phergie.org)
+ * @license http://phergie.org/license Simplified BSD License
+ * @package Phergie\Irc\Bot\React
+ */
+
+namespace Phergie\Irc\Bot\React;
+
+/**
+ * Interface for injection of the event queue factory, which resolves
+ * connection instances to event queue instances.
+ *
+ * @category Phergie
+ * @package Phergie\Irc\Bot\React
+ */
+interface EventQueueFactoryAwareInterface
+{
+    /**
+     * Sets the client for the implementing class to use.
+     *
+     * @param \Phergie\Irc\Bot\React\EventQueueFactoryInterface $queueFactory
+     */
+    public function setEventQueueFactory(EventQueueFactoryInterface $queueFactory);
+}

--- a/src/PluginProcessor/EventQueueFactoryInjector.php
+++ b/src/PluginProcessor/EventQueueFactoryInjector.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Phergie (http://phergie.org)
+ *
+ * @link http://github.com/phergie/phergie-irc-bot-react for the canonical source repository
+ * @copyright Copyright (c) 2008-2015 Phergie Development Team (http://phergie.org)
+ * @license http://phergie.org/license Simplified BSD License
+ * @package Phergie\Irc\Bot\React
+ */
+
+namespace Phergie\Irc\Bot\React\PluginProcessor;
+
+use Phergie\Irc\Bot\React\Bot;
+use Phergie\Irc\Bot\React\EventQueueFactoryAwareInterface;
+use Phergie\Irc\Bot\React\PluginInterface;
+
+/**
+ * Plugin processor that injects the plugin with the bot's client if
+ * possible.
+ *
+ * @category Phergie
+ * @package Phergie\Irc\Bot\React
+ */
+class EventQueueFactoryInjector implements PluginProcessorInterface
+{
+    /**
+     * Injects the bot's client into the plugin if it implements
+     * \Phergie\Irc\Bot\React\ClientAwareInterface.
+     *
+     * @param \Phergie\Irc\Bot\React\PluginInterface $plugin Loaded plugin
+     * @param \Phergie\Irc\Bot\React\Bot $bot Bot that loaded the plugin
+     */
+    public function process(PluginInterface $plugin, Bot $bot)
+    {
+        if ($plugin instanceof EventQueueFactoryAwareInterface) {
+            $plugin->setEventQueueFactory($bot->getEventQueueFactory());
+        }
+    }
+}

--- a/tests/AbstractPluginTest.php
+++ b/tests/AbstractPluginTest.php
@@ -76,6 +76,44 @@ class AbstractPluginTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Tests setClient().
+     */
+    public function testSetClient()
+    {
+        $client = Phake::mock('\Phergie\Irc\Client\React\ClientInterface');
+        $this->plugin->setClient($client);
+        $this->assertSame($client, $this->plugin->getClient());
+    }
+
+    /**
+     * Tests getClient().
+     */
+    public function testGetClient()
+    {
+        $client = $this->plugin->getClient();
+        $this->assertNull($client);
+    }
+
+    /**
+     * Tests setEventQueueFactory().
+     */
+    public function testSetEventQueueFactory()
+    {
+        $queueFactory = Phake::mock('\Phergie\Irc\Bot\React\EventQueueFactoryInterface');
+        $this->plugin->setEventQueueFactory($queueFactory);
+        $this->assertSame($queueFactory, $this->plugin->getEventQueueFactory());
+    }
+
+    /**
+     * Tests getEventQueueFactory().
+     */
+    public function testGetEventQueueFactory()
+    {
+        $queueFactory = $this->plugin->getEventQueueFactory();
+        $this->assertNull($queueFactory);
+    }
+
+    /**
      * Tests that the class under test implements PluginInterface.
      */
     public function testImplementsPluginInterface()

--- a/tests/BotTest.php
+++ b/tests/BotTest.php
@@ -428,6 +428,7 @@ class BotTest extends \PHPUnit_Framework_TestCase
 
         $logger = $this->getMockLogger();
         $client = $this->getMockClient();
+        $factory = $this->getMockEventQueueFactory();
         Phake::when($client)->getLogger()->thenReturn($logger);
 
         $config = array(
@@ -438,10 +439,12 @@ class BotTest extends \PHPUnit_Framework_TestCase
         $this->bot->setClient($client);
         $this->bot->setConfig($config);
         $this->bot->setLogger($logger);
+        $this->bot->setEventQueueFactory($factory);
         $this->bot->run();
 
         Phake::verify($plugin)->setEventEmitter($client);
         Phake::verify($plugin)->setClient($client);
+        Phake::verify($plugin)->setEventQueueFactory($factory);
         Phake::verify($plugin)->setLogger($logger);
     }
 


### PR DESCRIPTION
Plugins can now use the event queue factory to resolve connections to event queue instances, for processing asynchronous events without having to store event queue instances or play object ping-pong.

``` php
public function handleMyAsynchronousEvent(ConnectionInterface $connection, $message)
{
  $queue = $this->getEventQueueFactory()->getEventQueue($connection);
  $queue->ircPrivmsg($this->myOutputChannel, $message);
}
```