### PR TITLE
Add .editorconfig to show as much code style help as we can 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# EditorConfig
+# Not sure what this is? http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+
+[*.yml]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
Add .editorconfig to show as much code style help as we can in editors that support it

More info: http://editorconfig.org/

This will allow us to do some CS hinting in various editors.