### PR TITLE
#21 Adding .gitattributes to ignore some of the files and folders

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+/tests              export-ignore
+/.gitattributes     export-ignore
+/.gitignore         export-ignore
+/.travis.yml        export-ignore
+/.editorconfig      export-ignore
+/.php_cs            export-ignore
+/phpunit.xml        export-ignore


### PR DESCRIPTION
Adding .gitattributes to ignore some of the files and folders during packaging for the --prefer-dist

Based on #21 

* http://www.sitepoint.com/mastering-composer-tips-tricks/
* Credit to https://github.com/thephpleague/skeleton/blob/master/.gitattributes