### PR TITLE
Add custom fixer for discussed styling

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -1,5 +1,67 @@
 <?php
 
+use Symfony\CS\AbstractFixer;
+use Symfony\CS\FixerInterface;
+use Symfony\CS\Tokenizer\Token;
+use Symfony\CS\Tokenizer\Tokens;
+
+class ShortArraySpacesFixer extends AbstractFixer
+{
+    private static $emptySpace = false;
+
+    /**
+     * Adds a space in empty arrays declarations.
+     *
+     * @param boolean $emptySpace default: false
+     */
+    public static function setEmptySpace($emptySpace)
+    {
+        $this->emptySpace = $emptySpace;
+    }
+
+    public function fix(\SplFileInfo $file, $content)
+    {
+        $tokens = Tokens::fromCode($content);
+        for ($index = $tokens->count() - 1; 0 <= $index; --$index) {
+            if (!$tokens->isShortArray($index)) {
+                continue;
+            }
+
+            if (!$tokens[$index + 1]->isWhiteSpace()) {
+                $tokens->insertAt($index + 1, new Token([ T_WHITESPACE, ' ' ]));
+            }
+
+            $closeIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_SQUARE_BRACE, $index);
+            if (!$tokens[$closeIndex - 1]->isWhiteSpace()) {
+                $tokens->insertAt($closeIndex, new Token([ T_WHITESPACE, ' ' ]));
+            }
+
+            if ($tokens->getNextNonWhiteSpace($index) === ($closeIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_SQUARE_BRACE, $index))) {
+                $tokens->clearRange($index + 1, $closeIndex - 1);
+                if (self::$emptySpace) {
+                    $tokens->insertAt($index + 1, new Token([ T_WHITESPACE, ' ' ]));
+                }
+            }
+        }
+        return $tokens->generateCode();
+    }
+
+    public function getDescription()
+    {
+        return 'PHP short arrays should have spaces after opening bracket and before closing bracket';
+    }
+
+    public function getLevel()
+    {
+        return FixerInterface::CONTRIB_LEVEL;
+    }
+
+    public function getPriority()
+    {
+        return -10;
+    }
+}
+
 $finder = Symfony\CS\Finder\DefaultFinder::create()
     ->in(__DIR__.'/src')
     ->in(__DIR__.'/tests')
@@ -10,6 +72,7 @@ return Symfony\CS\Config\Config::create()
     // All PSR-1 and PSR-2 fixers are included here.
     ->level(Symfony\CS\FixerInterface::PSR2_LEVEL)
 
+    ->addCustomFixer(new ShortArraySpacesFixer())
     ->fixers([
         //  Accepted styling
         'short_array_syntax',               // Arrays should use the PHP 5.4 short-syntax.
@@ -26,6 +89,9 @@ return Symfony\CS\Config\Config::create()
 
         //  Non-essential styling
         'phpdoc_order',                     // Annotations in phpdocs should be ordered so that param annotations come first, then throws annotations, then return annotations.
+
+        // Custom styling
+        'short_array_spaces',
     ])
 
     ->finder($finder);

--- a/.php_cs
+++ b/.php_cs
@@ -1,11 +1,6 @@
 <?php
 
-use Symfony\CS\AbstractFixer;
-use Symfony\CS\FixerInterface;
-use Symfony\CS\Tokenizer\Token;
-use Symfony\CS\Tokenizer\Tokens;
-
-class ShortArraySpacesFixer extends AbstractFixer
+class ShortArraySpacesFixer extends Symfony\CS\AbstractFixer
 {
     private static $emptySpace = false;
 
@@ -21,25 +16,25 @@ class ShortArraySpacesFixer extends AbstractFixer
 
     public function fix(\SplFileInfo $file, $content)
     {
-        $tokens = Tokens::fromCode($content);
+        $tokens = Symfony\CS\Tokenizer\Tokens::fromCode($content);
         for ($index = $tokens->count() - 1; 0 <= $index; --$index) {
             if (!$tokens->isShortArray($index)) {
                 continue;
             }
 
             if (!$tokens[$index + 1]->isWhiteSpace()) {
-                $tokens->insertAt($index + 1, new Token([ T_WHITESPACE, ' ' ]));
+                $tokens->insertAt($index + 1, new Symfony\CS\Tokenizer\Token([ T_WHITESPACE, ' ' ]));
             }
 
-            $closeIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_SQUARE_BRACE, $index);
+            $closeIndex = $tokens->findBlockEnd(Symfony\CS\Tokenizer\Tokens::BLOCK_TYPE_SQUARE_BRACE, $index);
             if (!$tokens[$closeIndex - 1]->isWhiteSpace()) {
-                $tokens->insertAt($closeIndex, new Token([ T_WHITESPACE, ' ' ]));
+                $tokens->insertAt($closeIndex, new Symfony\CS\Tokenizer\Token([ T_WHITESPACE, ' ' ]));
             }
 
-            if ($tokens->getNextNonWhiteSpace($index) === ($closeIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_SQUARE_BRACE, $index))) {
+            if ($tokens->getNextNonWhiteSpace($index) === ($closeIndex = $tokens->findBlockEnd(Symfony\CS\Tokenizer\Tokens::BLOCK_TYPE_SQUARE_BRACE, $index))) {
                 $tokens->clearRange($index + 1, $closeIndex - 1);
                 if (self::$emptySpace) {
-                    $tokens->insertAt($index + 1, new Token([ T_WHITESPACE, ' ' ]));
+                    $tokens->insertAt($index + 1, new Symfony\CS\Tokenizer\Token([ T_WHITESPACE, ' ' ]));
                 }
             }
         }
@@ -53,7 +48,7 @@ class ShortArraySpacesFixer extends AbstractFixer
 
     public function getLevel()
     {
-        return FixerInterface::CONTRIB_LEVEL;
+        return Symfony\CS\FixerInterface::CONTRIB_LEVEL;
     }
 
     public function getPriority()
@@ -62,11 +57,11 @@ class ShortArraySpacesFixer extends AbstractFixer
     }
 }
 
-class MultilineOperatorsFixer extends AbstractFixer
+class MultilineOperatorsFixer extends Symfony\CS\AbstractFixer
 {
     public function fix(\SplFileInfo $file, $content)
     {
-        $tokens = Tokens::fromCode($content);
+        $tokens = Symfony\CS\Tokenizer\Tokens::fromCode($content);
         for ($index = $tokens->count() - 1; 0 <= $index; --$index) {
             if (!$tokens->isBinaryOperator($index)) {
                 continue;
@@ -79,7 +74,7 @@ class MultilineOperatorsFixer extends AbstractFixer
 
                 $prevToken = $tokens[$index - 1];
                 if (!$prevToken->isWhitespace()) {
-                    $tokens->insertAt($index, new Token([ T_WHITESPACE, "\n" . end($indent) ]));
+                    $tokens->insertAt($index, new Symfony\CS\Tokenizer\Token([ T_WHITESPACE, "\n" . end($indent) ]));
                 } elseif ($prevToken->isWhitespace([ 'whitespaces' => " \t" ])) {
                     $prevToken->setContent("\n" . end($indent) . ltrim($prevToken->getContent()));
                 }
@@ -95,7 +90,7 @@ class MultilineOperatorsFixer extends AbstractFixer
 
     public function getLevel()
     {
-        return FixerInterface::CONTRIB_LEVEL;
+        return Symfony\CS\FixerInterface::CONTRIB_LEVEL;
     }
 }
 

--- a/.php_cs
+++ b/.php_cs
@@ -2,6 +2,8 @@
 
 $finder = Symfony\CS\Finder\DefaultFinder::create()
     ->in(__DIR__.'/src')
+    ->in(__DIR__.'/tests')
+    ->append([ __DIR__.'/.php_cs' ])
 ;
 
 return Symfony\CS\Config\Config::create()

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ matrix:
     - php: 7
     - php: hhvm
 
+before_install:
+  - wget http://get.sensiolabs.org/php-cs-fixer.phar
+
 before_script:
   - composer self-update
   - composer install --dev
@@ -20,6 +23,7 @@ before_script:
 
 script:
   - ./vendor/bin/phpunit --coverage-clover build/cov/clover.xml
+  - output=$(php php-cs-fixer.phar fix -v --dry-run .); if [[ $output ]]; then while read -r line; do echo -e "$line"; done <<< "$output"; false; fi;
 
 after_script:
   - ./vendor/bin/coveralls -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_script:
 
 script:
   - ./vendor/bin/phpunit --coverage-clover build/cov/clover.xml
-  - output=$(php php-cs-fixer.phar fix -v --dry-run .); if [[ $output ]]; then while read -r line; do echo -e "$line"; done <<< "$output"; false; fi;
+  - output=$(php php-cs-fixer.phar fix -v --dry-run); if [[ $output ]]; then while read -r line; do echo -e "$line"; done <<< "$output"; false; fi;
 
 after_script:
   - ./vendor/bin/coveralls -v


### PR DESCRIPTION
This will correctly catch this 2 styles:
* Array syntax is `[]` or `[ 'key' => 'value' ]` (spaces after opening bracket and before closing bracket)
* Multi line operations: The operator should be prepended to the front of the next line.

To add a travis check on code styling a dev dependency must be added. Since php can't reference classes from a phar archive. If you like then i could add this, just tell me.

Also, i sent this merge to cs-fixer branch to prepare it to merge in master after all styling is discussed.