### PR TITLE
Do not filter non-empty IRC command parameters which cast to boolean false

### DIFF
--- a/src/EventQueue.php
+++ b/src/EventQueue.php
@@ -134,7 +134,7 @@ class EventQueue implements EventQueueInterface
     {
         $event->setPrefix($this->prefix);
         $event->setCommand($command);
-        $event->setParams(array_filter($params));
+        $event->setParams(array_filter($params, 'strlen'));
         $this->queue->insert($event, $this->getPriority($command, $params));
     }
 

--- a/tests/EventQueueTest.php
+++ b/tests/EventQueueTest.php
@@ -251,4 +251,27 @@ class EventQueueTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals([ $event ], $contents);
     }
+
+    /**
+     * Tests that non-empty parameter strings are not truncated.
+     */
+    public function testRequestFilter()
+    {
+        $this->assertNull($this->queue->extract());
+
+        $this->queue->ircMode('#test', '+n', '');
+        $this->queue->ircPrivmsg('TestUser', '0');
+
+        $event = $this->queue->extract();
+        $this->assertInstanceOf('\Phergie\Irc\Event\EventInterface', $event);
+        $this->assertEquals('MODE', $event->getCommand());
+        $this->assertEquals([ '#test', '+n' ], $event->getParams());
+
+        $event = $this->queue->extract();
+        $this->assertInstanceOf('\Phergie\Irc\Event\EventInterface', $event);
+        $this->assertEquals('PRIVMSG', $event->getCommand());
+        $this->assertEquals([ 'TestUser', '0' ], $event->getParams());
+
+        $this->assertNull($this->queue->extract());
+    }
 }


### PR DESCRIPTION
```php
EventQueue::ircPrivmsg('#channel', '0');
```

currently yields:

```
PHP Fatal error:  Uncaught ArgumentCountError: Too few arguments to function Phergie\Irc\Client\React\WriteStream::ircPrivmsg(), 1 passed and exactly 2 expected in /truncated/vendor/phergie/phergie-irc-client-react/src/WriteStream.php:432
Stack trace:
#0 [internal function]: Phergie\Irc\Client\React\WriteStream->ircPrivmsg('#channel')
#1 /truncated/vendor/phergie/phergie-irc-bot-react/src/Bot.php(533): call_user_func_array(Array, Array)
#2 /truncated/vendor/phergie/phergie-irc-bot-react/src/Bot.php(498): Phergie\Irc\Bot\React\Bot->processOutgoingEvents(Object(Phergie\Irc\Connection), Object(Phergie\Irc\Client\React\WriteStream))
#3 /truncated/vendor/phergie/phergie-irc-bot-react/src/Bot.php(466): Phergie\Irc\Bot\React\Bot->processClientEvent('irc.sent', Array, Object(Phergie\Irc\Connection), Object(Phergie\Irc\Client\React\WriteStream))
#4 /truncated/vendor/evenement/evenement/src/Evenement/EventEmitterTrait.php(123): Phergie\Irc\Bot\React\Bot->Phergie\Irc\Bot\React\{closure}(' in /truncated/vendor/phergie/phergie-irc-client-react/src/WriteStream.php on line 432
```

due to the following line in `EventQueue::queueRequest`:

```php
$event->setParams(array_filter($params));
```

which filters any string that casts to boolean `false`.

Using the callback `strlen` mitigates against this, by filtering out empty variables and zero-length strings, but not `'0'`.